### PR TITLE
Fix Instrumentation ClassNotFound

### DIFF
--- a/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
+++ b/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
@@ -152,7 +152,7 @@ public class JavaAgent {
         @Override
         public void onError(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded,
                             Throwable throwable) {
-            logger.error("Enhance class " + typeName + " error.", throwable);
+            logger.error("Enhance class " + typeName + "[ " + classLoader.getClass().getName() + " ]" + "error.", throwable);
         }
 
         @Override

--- a/agent-plugins/agent-dubbo-2.7.x-plugin/pom.xml
+++ b/agent-plugins/agent-dubbo-2.7.x-plugin/pom.xml
@@ -41,6 +41,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-dubbo-plugin/pom.xml
+++ b/agent-plugins/agent-dubbo-plugin/pom.xml
@@ -39,6 +39,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/agent-plugins/agent-feign-plugin/pom.xml
+++ b/agent-plugins/agent-feign-plugin/pom.xml
@@ -24,6 +24,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-httpClient-4.x-plugin/pom.xml
+++ b/agent-plugins/agent-httpClient-4.x-plugin/pom.xml
@@ -40,6 +40,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/pom.xml
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/pom.xml
@@ -22,6 +22,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/pom.xml
+++ b/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/pom.xml
@@ -21,6 +21,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/agent-plugins/agent-jedis-2.x-plugin/pom.xml
+++ b/agent-plugins/agent-jedis-2.x-plugin/pom.xml
@@ -18,6 +18,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-lettuce-plugins/pom.xml
+++ b/agent-plugins/agent-lettuce-plugins/pom.xml
@@ -26,6 +26,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/agent-plugins/agent-okhttp-3.x-plugin/pom.xml
+++ b/agent-plugins/agent-okhttp-3.x-plugin/pom.xml
@@ -20,6 +20,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-okhttp-4.x-plugin/pom.xml
+++ b/agent-plugins/agent-okhttp-4.x-plugin/pom.xml
@@ -22,6 +22,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/agent-plugins/agent-rocketmq-4.x-plugin/pom.xml
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/pom.xml
@@ -21,6 +21,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-sdk-plugin/pom.xml
+++ b/agent-plugins/agent-sdk-plugin/pom.xml
@@ -11,22 +11,17 @@
 
     <artifactId>agent-sdk-plugin</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>cloud.erda</groupId>
             <artifactId>msp-monitor-sdk</artifactId>
-            <version>1.0.5</version>
-            <scope>provided</scope>
+            <version>1.0.6</version>
         </dependency>
     </dependencies>
 

--- a/agent-plugins/agent-servlet-plugins/agent-servlet-commons/pom.xml
+++ b/agent-plugins/agent-servlet-plugins/agent-servlet-commons/pom.xml
@@ -18,6 +18,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-sharding-sphere-4.x-plugin/pom.xml
+++ b/agent-plugins/agent-sharding-sphere-4.x-plugin/pom.xml
@@ -20,6 +20,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/agent-plugins/agent-spring-plugins/pom.xml
+++ b/agent-plugins/agent-spring-plugins/pom.xml
@@ -32,6 +32,7 @@
             <groupId>cloud.erda</groupId>
             <artifactId>agent-app-insight-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/agent-sdk/pom.xml
+++ b/agent-sdk/pom.xml
@@ -2,16 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>java-agent</artifactId>
-        <groupId>cloud.erda</groupId>
-        <version>1.0.0</version>
-    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>msp-monitor-sdk</artifactId>
-    <packaging>jar</packaging>
+    <groupId>cloud.erda</groupId>
     <name>msp-monitor-sdk</name>
+    <packaging>jar</packaging>
+
+    <artifactId>msp-monitor-sdk</artifactId>
+    <version>1.0.6</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/agent-sdk/src/main/java/cloud/erda/msp/monitor/metrics/MethodInvoke.java
+++ b/agent-sdk/src/main/java/cloud/erda/msp/monitor/metrics/MethodInvoke.java
@@ -16,10 +16,17 @@
 
 package cloud.erda.msp.monitor.metrics;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * @author liuhaoyang
  * @date 2021/8/3 10:57
  */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
 public @interface MethodInvoke {
 
     String value() default "";


### PR DESCRIPTION
Fix msp-monitor-sdk @Trace and @MethdoInvoke not found when call MethodInvokeAnnotationInstrumentation
```
ERROR 2021-08-04 23:53:49 JavaAgent :  Enhance class io.terminus.trantorframework.spi.invoker.InJvmFunctionImplInvoker error. 
java.lang.NoClassDefFoundError: cloud/erda/msp/monitor/metrics/MethodInvoke
```