### PR TITLE
Add peer_service_scope in the metric of HTTP client

### DIFF
--- a/agent-core/src/main/java/cloud/erda/agent/core/config/AgentConfig.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/config/AgentConfig.java
@@ -21,7 +21,7 @@ import cloud.erda.agent.core.config.loader.Configuration;
 import org.apache.skywalking.apm.agent.core.logging.core.LogLevel;
 
 public class AgentConfig implements Config {
-    @Configuration(name = "TERMINUS_KEY")
+    @Configuration(name = "TERMINUS_KEY", defaultValue = "")
     private String _terminusKey;
 
     @Configuration(name = "TERMINUS_SPOT_SAMPLING_RATE", defaultValue = "50")

--- a/agent-core/src/main/java/cloud/erda/agent/core/utils/Constants.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/utils/Constants.java
@@ -82,6 +82,12 @@ public class Constants {
 
         public static final String PEER_SERVICE = "peer_service";
 
+        public static final String PEER_SERVICE_SCOPE = "peer_service_scope";
+
+        public static final String PEER_SERVICE_EXTERNAL = "external";
+
+        public static final String PEER_SERVICE_INTERNAL = "internal";
+
         public static final String SPAN_LAYER = "span_layer";
 
         public static final String SPAN_LAYER_RPC = "rpc";

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/CallInterceptorUtils.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/CallInterceptorUtils.java
@@ -16,6 +16,8 @@
 
 package cloud.erda.agent.plugin.okhttp.common;
 
+import cloud.erda.agent.core.config.AgentConfig;
+import cloud.erda.agent.core.config.loader.ConfigAccessor;
 import cloud.erda.agent.core.tracing.Tracer;
 import cloud.erda.agent.core.tracing.TracerManager;
 import cloud.erda.agent.core.tracing.propagator.TextMapCarrier;
@@ -70,11 +72,12 @@ public class CallInterceptorUtils {
             return transactionMetricBuilder;
         }
 
-//        String terminusKey = response.header(Constants.Carriers.RESPONSE_TERMINUS_KEY);
-//        if (!Strings.isEmpty(terminusKey)) {
-//            return null;
-//        }
-
+        String responseTerminusKey = response.header(Constants.Carriers.RESPONSE_TERMINUS_KEY);
+        if (responseTerminusKey != null && ConfigAccessor.Default.getConfig(AgentConfig.class).terminusKey().equals(responseTerminusKey)) {
+            transactionMetricBuilder.tag(PEER_SERVICE_SCOPE, PEER_SERVICE_INTERNAL);
+        } else {
+            transactionMetricBuilder.tag(PEER_SERVICE_SCOPE, PEER_SERVICE_EXTERNAL);
+        }
         TransactionMetricUtils.handleStatusCode(transactionMetricBuilder, response.code());
         return transactionMetricBuilder;
     }

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/RestExecuteInterceptor.java
@@ -18,9 +18,6 @@
 
 package cloud.erda.agent.plugin.spring.resttemplate.sync;
 
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.context.IMethodInterceptContext;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import cloud.erda.agent.core.tracing.Scope;
 import cloud.erda.agent.core.tracing.SpanContext;
 import cloud.erda.agent.core.tracing.Tracer;
@@ -30,11 +27,14 @@ import cloud.erda.agent.core.tracing.span.Span;
 import cloud.erda.agent.core.utils.Constants;
 import cloud.erda.agent.core.utils.HttpUtils;
 import cloud.erda.agent.core.utils.TracerUtils;
+import cloud.erda.agent.plugin.app.insight.MetricReporter;
 import cloud.erda.agent.plugin.app.insight.transaction.TransactionMetricBuilder;
 import cloud.erda.agent.plugin.app.insight.transaction.TransactionMetricContext;
-import cloud.erda.agent.plugin.app.insight.MetricReporter;
 import cloud.erda.agent.plugin.app.insight.transaction.TransactionMetricUtils;
 import cloud.erda.agent.plugin.spring.EnhanceCommonInfo;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.context.IMethodInterceptContext;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.springframework.http.HttpMethod;
 
 import java.net.URI;

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/RestRequestInterceptor.java
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/RestRequestInterceptor.java
@@ -19,11 +19,11 @@
 
 package cloud.erda.agent.plugin.spring.resttemplate.sync;
 
-import org.apache.skywalking.apm.agent.core.util.Strings;
+import cloud.erda.agent.plugin.spring.EnhanceCommonInfo;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.context.IMethodInterceptContext;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
-import cloud.erda.agent.plugin.spring.EnhanceCommonInfo;
+import org.apache.skywalking.apm.agent.core.util.Strings;
 import org.springframework.http.client.AbstractClientHttpRequest;
 
 import java.util.Map;


### PR DESCRIPTION
When there are terminus_keys in the response header of the HTTP client request and equal to the terms of the current service's terminus_key the requested service is considered to be an internal service of the system.
This feature can be used to identify internal and external HTTP calls in APM.